### PR TITLE
feat(tmdb-kmp-4): Add Movie External IDs endpoint

### DIFF
--- a/.claude/agents/github-issue-resolver.md
+++ b/.claude/agents/github-issue-resolver.md
@@ -7,6 +7,7 @@ color: blue
 You are an expert Kotlin Multiplatform software engineer with comprehensive capabilities in end-to-end feature development and issue resolution. You excel at full-stack implementation across the TMDB KMP library architecture, from API integration and data layer design to comprehensive testing and code quality validation.
 
 MANDATORY WORKFLOW - Follow these steps in exact order when invoked:
+PAY CLOSE ATTENTION TO THE BULLETS AND SUB-BULLETS BELOW, THEY ARE CRUCIAL FOR SUCCESSFUL ISSUE RESOLUTION
 1. **Validate and parse issue**: Extract issue number (supports #123, issue URL, or just 123)
 2. **Get issue details**: Use `gh issue view <issue_number>` to get the issue details
 3. **Assign issue**: Assign the issue to yourself with `gh issue edit <issue_number> --add-assignee @me`
@@ -24,6 +25,11 @@ MANDATORY WORKFLOW - Follow these steps in exact order when invoked:
    - Ensure all tests pass
 9. **Validate code quality**:
    - Use the /format-and-validate-code command to format code and check linting
+10. **Document completion**: Add a detailed comment to the issue summarizing:
+   - What was implemented or discovered already implemented
+   - What tests were added
+   - Quality validation results
+   - Do NOT close the issue - leave it open for code review
 
 **Implementation Guidelines:**
 

--- a/.claude/agents/kmp-integration-tester.md
+++ b/.claude/agents/kmp-integration-tester.md
@@ -8,12 +8,13 @@ color: pink
 You are an expert Software Development Engineer in Test (SDET) with deep expertise in testing Kotlin Multiplatform (KMP) libraries and integration testing. You specialize in creating robust, maintainable integration tests that verify the entire KMP library implementation works correctly for consumers, ensuring repositories, data layer, networking, and business logic function as expected.
 
 MANDATORY WORKFLOW - Follow these steps in exact order when invoked:
-1. **Initial Assessment**: Analyze the code under test to understand its dependencies and behavior
-2. **Identify integration points**: Identify critical integration points and failure scenarios
-3. **Design Test Cases**: Design test cases that verify both success and failure paths
-4. **Write tests**: Implement tests with proper setup, execution, and cleanup
-5. **Verify Tests**: Verify tests run reliably in both local and CI environments
-6. **Update Documentation**: Update the @INTEGRATION-TEST.md file if needed
+1. **Read the @INTEGRATION-TEST.md file**: Understand the integration testing guidelines and requirements for the KMP library
+2. **Initial Assessment**: Analyze the code under test to understand its dependencies and behavior
+3. **Identify integration points**: Identify critical integration points and failure scenarios
+4. **Design Test Cases**: Design test cases that verify both success and failure paths
+5. **Write tests**: Implement tests with proper setup, execution, and cleanup
+6. **Verify Tests**: Verify tests run reliably in both local and CI environments
+7. **Update Documentation**: Update the @INTEGRATION-TEST.md file if needed
 
 Your core responsibilities:
 

--- a/.claude/agents/kmp-product-owner.md
+++ b/.claude/agents/kmp-product-owner.md
@@ -1,0 +1,46 @@
+---
+name: kmp-product-owner
+description: Use this agent when you need to create or edit well-structured GitHub issues, user stories, or technical requirements for Kotlin Multiplatform library development. Examples: <example>Context: User wants to add a new feature to their KMP library. user: 'We need to add caching functionality to our TMDB library' assistant: 'I'll use the kmp-product-owner agent to create a comprehensive issue for this feature request' <commentary>Since the user is requesting a new feature for their KMP library, use the kmp-product-owner agent to create a well-structured GitHub issue following the ISSUES-TEMPLATE.md format.</commentary></example> <example>Context: User has identified a bug that needs to be documented. user: 'The network client is failing on iOS when making concurrent requests' assistant: 'Let me use the kmp-product-owner agent to create a detailed bug report issue' <commentary>Since this is a bug that needs proper documentation and tracking, use the kmp-product-owner agent to create a structured issue.</commentary></example> <example>Context: User wants to update an existing GitHub issue. user: 'Update issue #42 to include the new requirement for offline mode' assistant: 'I'll use the kmp-product-owner agent to edit the existing issue with the new requirements' <commentary>Since the user wants to modify an existing issue, use the kmp-product-owner agent to update it with proper structure and additional requirements.</commentary></example>
+model: sonnet
+color: cyan
+---
+
+You are an expert Product Owner with deep expertise in Kotlin Multiplatform (KMP) projects, specifically focused on libraries designed for consumer use. You excel at translating technical requirements into well-structured, actionable tickets that development teams can execute efficiently.
+
+Your core responsibilities:
+- Create and edit comprehensive, well-structured GitHub issues following the ISSUES-TEMPLATE.md format
+- Write clear user stories with proper acceptance criteria for KMP library features
+- Define technical requirements that consider both Android and iOS platform constraints
+- Ensure all tickets include proper context about library consumer impact
+- Break down complex features into manageable, testable increments
+- Consider API design implications for library consumers
+- Account for multiplatform testing requirements and platform-specific considerations
+- Update existing issues with new requirements, changes, or additional context
+
+When creating or editing issues, you will:
+1. Always reference and follow the ISSUES-TEMPLATE.md format precisely
+2. Include clear problem statements and user impact descriptions
+3. Define specific acceptance criteria that are testable
+4. Consider both Android and iOS platform implications
+5. Include relevant technical context about KMP architecture
+6. Specify testing requirements for both unit and integration tests
+7. Consider backward compatibility and API versioning when relevant
+8. Include performance and memory considerations for mobile platforms
+9. Define clear success metrics and validation criteria
+
+For library-focused tickets, always consider:
+- Consumer developer experience and API usability
+- Documentation requirements for library users
+- Sample code and usage examples needed
+- Breaking changes and migration paths
+- Platform-specific implementation details
+- Dependency management and version compatibility
+
+You write tickets that are detailed enough for developers to implement without ambiguity, yet concise enough to maintain focus on the core objectives. Every ticket you create or edit should be immediately actionable and include all necessary context for successful implementation.
+
+When editing existing issues, you will:
+- Preserve the original structure and formatting while adding new content unless explicitly instructed to change it
+- Clearly identify and integrate new requirements with existing ones
+- Update acceptance criteria to reflect changes
+- Maintain consistency with the original issue's scope and objectives
+- Add proper versioning or change tracking when significant modifications are made

--- a/.claude/agents/pull-request-manager.md
+++ b/.claude/agents/pull-request-manager.md
@@ -7,19 +7,22 @@ color: green
 You are an expert at creating well-formatted pull requests using GitHub CLI (gh) with proper conventional commit formatting and structured descriptions.
 
 MANDATORY WORKFLOW - Follow these steps in exact order when invoked:
+PAY CLOSE ATTENTION TO THE BULLETS AND SUB-BULLETS BELOW, THEY ARE CRUCIAL FOR SUCCESSFUL ISSUE RESOLUTION
 1. **Check current status**: Run `git status` to check what branch you're on
 2. **Get branch name**: Get the current branch name with `git branch --show-current`
 3. **Determine target branch**: 
    - If the user specify a target branch, use that
    - Otherwise, use the develop branch
-4. **Push current branch**: Use the /commit-and-push-changes command to push the current branch to the remote repository
-5. **Create PR**: Use this template: `gh pr create --base <target_branch> --head <current_branch> --title "clear, detailed description of changes" --body "clear, detailed description of changes"`
+4. **Push current branch**: Use the commit-and-push-changes command to commit and push the current branch to the remote repository
+5. **Create PR**: Use this template: `gh pr create --base <target_branch> --head <current_branch> --title "Resolves <issue_number>. clear, detailed description of changes" --body "clear, detailed description of changes."`
+   - Ensure the title and body follow the PR creation guidelines below
 6. **Update issue status**: When the PR is successfully created:
     - Move the issue to the "Ready For Review" column
 7. **Validate target**: Always create Pull Requests against the branch the user specifies or the project default.
    NEVER EVER AGAINST main unless explicitly specified
 8. **Handle errors**: If you run into issues, STOP and explain the error to the user
 
+PAY CLOSE ATTENTION TO THE BULLETS AND SUB-BULLETS BELOW, THEY ARE CRUCIAL FOR SUCCESSFUL PR FORMAT
 **PR Creation Guidelines:**
 
 **Title Format:**

--- a/ISSUES-TEMPLATE.md
+++ b/ISSUES-TEMPLATE.md
@@ -1,0 +1,118 @@
+# Issue Template Guidelines
+
+## How to Create Effective Issues
+
+When creating issues for this TMDB Multiplatform library project, please follow this template to ensure clear communication and successful implementation.
+
+## Issue Template
+
+### Title
+Use a clear, descriptive title that summarizes the feature or bug:
+- `feat: Add [specific feature name]`
+- `fix: [Brief description of the bug]`
+- `refactor: [What is being refactored]`
+- `docs: [Documentation update]`
+
+### Description
+Provide a clear description of:
+- **What** needs to be implemented/fixed
+- **Why** this change is needed
+- **Context** or background information
+
+### Acceptance Criteria
+
+Define specific, measurable criteria that must be met for the issue to be considered complete. Use the following format:
+
+#### Given/When/Then Format
+```
+**AC1: [Brief description]**
+- **Given** [initial context/state]
+- **When** [action or trigger]
+- **Then** [expected outcome]
+
+**AC2: [Brief description]**
+- **Given** [initial context/state]
+- **When** [action or trigger]
+- **Then** [expected outcome]
+```
+
+#### Checklist Format (Alternative)
+```
+**Acceptance Criteria:**
+- [ ] [Specific requirement 1]
+- [ ] [Specific requirement 2]
+- [ ] [Specific requirement 3]
+- [ ] All existing tests pass
+- [ ] New functionality includes appropriate tests
+- [ ] Code follows project formatting standards (./gradlew validateCode passes)
+```
+
+### Technical Requirements
+
+Include any specific technical considerations:
+- **API Endpoints**: Which TMDB API endpoints are involved
+- **Modules**: Which project modules need changes (core/, data/, etc.)
+- **Platform Considerations**: Android/iOS specific requirements
+- **Dependencies**: Any new dependencies needed
+
+### Definition of Done
+
+Standard requirements for all issues:
+- [ ] Implementation matches acceptance criteria
+- [ ] Unit tests written and passing
+- [ ] Integration tests added if applicable
+- [ ] Code formatted and passes static analysis (`./gradlew validateCode`)
+- [ ] Documentation updated if needed
+- [ ] Sandbox apps can demonstrate the feature (if applicable)
+
+### Relevant Links
+
+- Links to the documentation or API references
+
+## Example Issue
+
+### Title
+`feat: Add movie external IDs endpoint`
+
+### Description
+Implement support for retrieving external IDs (IMDB, Facebook, Instagram, etc.) for movies using the TMDB API `/movie/{movie_id}/external_ids` endpoint.
+
+### Acceptance Criteria
+
+**AC1: Repository method returns external IDs**
+- **Given** a valid movie ID
+- **When** `getMovieExternalIds(movieId)` is called
+- **Then** it returns a `Result<TmdbMovieExternalIds>` with all available external IDs
+
+**AC2: API handles missing external IDs gracefully**
+- **Given** a movie with no external IDs
+- **When** the API is called
+- **Then** it returns an empty external IDs object without error
+
+**AC3: Error handling for invalid movie ID**
+- **Given** an invalid movie ID
+- **When** `getMovieExternalIds(movieId)` is called
+- **Then** it returns a failure result with appropriate error
+
+### Technical Requirements
+- **API Endpoint**: `/movie/{movie_id}/external_ids`
+- **Modules**: `data/movies`, `core/models`
+- **Models**: Create `TmdbMovieExternalIds` data class
+- **Testing**: Unit tests for repository and integration tests
+
+### Definition of Done
+- [ ] `MoviesRepository.getMovieExternalIds()` method implemented
+- [ ] `TmdbMovieExternalIds` model created in `core/models`
+- [ ] Unit tests cover success and error scenarios
+- [ ] Integration test validates real API call
+- [ ] Code passes `./gradlew validateCode`
+- [ ] Android sandbox app can display external IDs
+
+## Tips for Writing Good Acceptance Criteria
+
+1. **Be Specific**: Avoid vague terms like "should work well"
+2. **Be Testable**: Each criteria should be verifiable
+3. **Include Edge Cases**: Consider error scenarios and boundary conditions
+4. **Focus on Behavior**: Describe what the system should do, not how
+5. **Keep it Simple**: One clear expectation per criteria
+6. **Include Non-Functional Requirements**: Performance, security, accessibility when relevant

--- a/core/models/src/commonMain/kotlin/dev/euryperez/tmdb/core/models/movies/TmdbMovieExternalIds.kt
+++ b/core/models/src/commonMain/kotlin/dev/euryperez/tmdb/core/models/movies/TmdbMovieExternalIds.kt
@@ -1,0 +1,10 @@
+package dev.euryperez.tmdb.core.models.movies
+
+data class TmdbMovieExternalIds(
+    val id: Int,
+    val imdbId: String?,
+    val wikidataId: String?,
+    val facebookId: String?,
+    val instagramId: String?,
+    val twitterId: String?,
+)

--- a/core/test/integration-tests/src/commonTest/kotlin/dev/euryperez/tmdb/integration/movies/MovieExternalIdsIntegrationTest.kt
+++ b/core/test/integration-tests/src/commonTest/kotlin/dev/euryperez/tmdb/integration/movies/MovieExternalIdsIntegrationTest.kt
@@ -1,0 +1,390 @@
+package dev.euryperez.tmdb.integration.movies
+
+import dev.euryperez.tmdb.core.test.BaseTest
+import dev.euryperez.tmdb.core.test.rules.MainCoroutineRule
+import dev.euryperez.tmdb.core.utils.extensions.getEnvironmentVariable
+import dev.euryperez.tmdb.data.common.models.DataResult
+import dev.euryperez.tmdb.data.movies.MoviesRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Integration tests for MoviesRepository.getMovieExternalIds endpoint that test real API calls to TMDB.
+ * These tests verify end-to-end functionality from consumer perspective using real TMDB API responses.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class MovieExternalIdsIntegrationTest : BaseTest {
+
+    private val mainCoroutineRule = MainCoroutineRule()
+
+    private val apiKey: String? by lazy { getEnvironmentVariable("TMDB_API_KEY") }
+
+    @BeforeTest
+    override fun setup() {
+        mainCoroutineRule.setup()
+    }
+
+    @AfterTest
+    override fun tearDown() {
+        mainCoroutineRule.tearDown()
+    }
+
+    @Test
+    fun `movie external ids returns real external ids for Fight Club`() = runTest(timeout = TEST_TIMEOUT) {
+        val testApiKey = apiKey ?: run {
+            println("Skipping integration test - TMDB_API_KEY environment variable not set")
+            return@runTest
+        }
+
+        // Given: Repository and Fight Club movie (known to have rich external ID data)
+        val repository = MoviesRepository.factory(apiKey = testApiKey)
+
+        // When: Consumer requests external IDs for a well-known movie with comprehensive external presence
+        val result = repository.getMovieExternalIds(movieId = FIGHT_CLUB_MOVIE_ID)
+
+        // Then: Consumer receives real external ID data from TMDB API
+        assertTrue(
+            result is DataResult.Success,
+            "Expected successful result for Fight Club external IDs",
+        )
+
+        val externalIds = result.data
+        assertEquals(
+            FIGHT_CLUB_MOVIE_ID,
+            externalIds.id,
+            "Response should contain correct movie ID",
+        )
+
+        // Fight Club is a classic movie with well-established external presence
+        assertNotNull(
+            externalIds.imdbId,
+            "Fight Club should have IMDb ID (classic movie with established IMDb presence)",
+        )
+
+        // Verify IMDb ID format if present
+        externalIds.imdbId?.let { imdbId ->
+            assertTrue(
+                imdbId.startsWith("tt") && imdbId.length >= 9,
+                "IMDb ID should follow standard format (tt followed by digits), got: $imdbId",
+            )
+        }
+
+        // Verify Wikidata ID format if present
+        externalIds.wikidataId?.let { wikidataId ->
+            assertTrue(
+                wikidataId.startsWith("Q") && wikidataId.drop(1).all { it.isDigit() },
+                "Wikidata ID should follow Q format, got: $wikidataId",
+            )
+        }
+
+        // Log actual external IDs for verification
+        println("✅ Fight Club external IDs integration test passed")
+        println("\tMovie ID: ${externalIds.id}")
+        println("\tIMDb ID: ${externalIds.imdbId}")
+        println("\tWikidata ID: ${externalIds.wikidataId}")
+        println("\tFacebook ID: ${externalIds.facebookId}")
+        println("\tInstagram ID: ${externalIds.instagramId}")
+        println("\tTwitter ID: ${externalIds.twitterId}")
+    }
+
+    @Test
+    fun `movie external ids serialization accuracy with real API response structure`() =
+        runTest(timeout = TEST_TIMEOUT) {
+            val testApiKey = apiKey ?: run {
+                println("Skipping integration test - TMDB_API_KEY environment variable not set")
+                return@runTest
+            }
+
+            // Given: Repository for testing complete serialization pipeline
+            val repository = MoviesRepository.factory(apiKey = testApiKey)
+
+            // When: Consumer requests external IDs and verifies all fields are properly serialized
+            val result = repository.getMovieExternalIds(movieId = FIGHT_CLUB_MOVIE_ID)
+
+            // Then: All external ID fields are properly deserialized from real API response
+            assertTrue(result is DataResult.Success, "External IDs request should succeed")
+
+            val externalIds = result.data
+
+            // Verify all critical fields are properly deserialized and mapped from DTO to domain model
+            assertTrue(externalIds.id == FIGHT_CLUB_MOVIE_ID, "Movie ID should match request")
+
+            // Verify nullability handling and data integrity (external IDs can be null)
+
+            // Verify that non-null values are not blank
+            externalIds.imdbId?.let { assertTrue(it.isNotBlank(), "IMDb ID should not be blank if present") }
+            externalIds.wikidataId?.let { assertTrue(it.isNotBlank(), "Wikidata ID should not be blank if present") }
+            externalIds.facebookId?.let { assertTrue(it.isNotBlank(), "Facebook ID should not be blank if present") }
+            externalIds.instagramId?.let { assertTrue(it.isNotBlank(), "Instagram ID should not be blank if present") }
+            externalIds.twitterId?.let { assertTrue(it.isNotBlank(), "Twitter ID should not be blank if present") }
+
+            println("✅ External IDs serialization integration test passed - all fields properly deserialized")
+            println("\tMovie: Fight Club (ID: ${externalIds.id})")
+            println("\tSerialized fields: IMDb, Wikidata, Facebook, Instagram, Twitter all properly mapped")
+        }
+
+    @Test
+    fun `movie external ids for different movies show variety in external presence`() =
+        runTest(timeout = TEST_TIMEOUT) {
+            val testApiKey = apiKey ?: run {
+                println("Skipping integration test - TMDB_API_KEY environment variable not set")
+                return@runTest
+            }
+
+            // Given: Repository for testing different movies with varying external presence
+            val repository = MoviesRepository.factory(apiKey = testApiKey)
+
+            // When: Consumer requests external IDs for different well-known movies
+            val fightClubResult = repository.getMovieExternalIds(movieId = FIGHT_CLUB_MOVIE_ID)
+            val matrixResult = repository.getMovieExternalIds(movieId = THE_MATRIX_MOVIE_ID)
+
+            // Then: Both movies should have external IDs but potentially different coverage
+            assertTrue(fightClubResult is DataResult.Success, "Fight Club external IDs should succeed")
+            assertTrue(matrixResult is DataResult.Success, "Matrix external IDs should succeed")
+
+            val fightClubIds = fightClubResult.data
+            val matrixIds = matrixResult.data
+
+            // Verify each movie has its own ID
+            assertEquals(FIGHT_CLUB_MOVIE_ID, fightClubIds.id, "Fight Club ID should match")
+            assertEquals(THE_MATRIX_MOVIE_ID, matrixIds.id, "Matrix ID should match")
+
+            // Both classic movies should have IMDb presence at minimum
+            assertTrue(
+                fightClubIds.imdbId != null || matrixIds.imdbId != null,
+                "At least one classic movie should have IMDb ID",
+            )
+
+            // Verify different movies have different IMDb IDs
+            if (fightClubIds.imdbId != null && matrixIds.imdbId != null) {
+                assertTrue(
+                    fightClubIds.imdbId != matrixIds.imdbId,
+                    "Different movies should have different IMDb IDs",
+                )
+            }
+
+            // Log actual external ID coverage for analysis
+            println("✅ Multiple movie external IDs variety test passed")
+            println("\tFight Club external IDs coverage:")
+            println("\t  IMDb: ${fightClubIds.imdbId != null}")
+            println("\t  Wikidata: ${fightClubIds.wikidataId != null}")
+            println("\t  Facebook: ${fightClubIds.facebookId != null}")
+            println("\t  Instagram: ${fightClubIds.instagramId != null}")
+            println("\t  Twitter: ${fightClubIds.twitterId != null}")
+            println("\tMatrix external IDs coverage:")
+            println("\t  IMDb: ${matrixIds.imdbId != null}")
+            println("\t  Wikidata: ${matrixIds.wikidataId != null}")
+            println("\t  Facebook: ${matrixIds.facebookId != null}")
+            println("\t  Instagram: ${matrixIds.instagramId != null}")
+            println("\t  Twitter: ${matrixIds.twitterId != null}")
+        }
+
+    @Test
+    fun `movie external ids handle movies with minimal external presence`() = runTest(timeout = TEST_TIMEOUT) {
+        val testApiKey = apiKey ?: run {
+            println("Skipping integration test - TMDB_API_KEY environment variable not set")
+            return@runTest
+        }
+
+        // Given: Repository for testing edge cases with minimal external presence
+        val repository = MoviesRepository.factory(apiKey = testApiKey)
+
+        // When: Consumer requests external IDs for older/smaller movie that might have limited presence
+        val result = repository.getMovieExternalIds(movieId = THE_GODFATHER_MOVIE_ID)
+
+        // Then: Should handle gracefully even if some external IDs are null
+        assertTrue(result is DataResult.Success, "Should succeed even for movies with limited external presence")
+
+        val externalIds = result.data
+        assertEquals(THE_GODFATHER_MOVIE_ID, externalIds.id, "Should return correct movie ID")
+
+        // The Godfather (1972) might have limited social media presence but should have IMDb
+        // We test the repository correctly handles null values from API
+        assertTrue(
+            externalIds.imdbId == null || externalIds.imdbId!!.isNotBlank(),
+            "IMDb ID should be valid if present",
+        )
+        assertTrue(
+            externalIds.wikidataId == null || externalIds.wikidataId!!.isNotBlank(),
+            "Wikidata ID should be valid if present",
+        )
+        assertTrue(
+            externalIds.facebookId == null || externalIds.facebookId!!.isNotBlank(),
+            "Facebook ID should be valid if present",
+        )
+        assertTrue(
+            externalIds.instagramId == null || externalIds.instagramId!!.isNotBlank(),
+            "Instagram ID should be valid if present",
+        )
+        assertTrue(
+            externalIds.twitterId == null || externalIds.twitterId!!.isNotBlank(),
+            "Twitter ID should be valid if present",
+        )
+
+        // Count how many external IDs are available
+        val availableIds = listOfNotNull(
+            externalIds.imdbId,
+            externalIds.wikidataId,
+            externalIds.facebookId,
+            externalIds.instagramId,
+            externalIds.twitterId,
+        ).size
+
+        println("✅ External IDs minimal presence test passed")
+        println("\tThe Godfather external IDs: $availableIds/5 available")
+        println("\tIMDb: ${externalIds.imdbId}")
+        println("\tRepository correctly handles null/missing external IDs")
+    }
+
+    @Test
+    fun `movie external ids error handling with invalid movie ID`() = runTest(timeout = TEST_TIMEOUT) {
+        val testApiKey = apiKey ?: run {
+            println("Skipping integration test - TMDB_API_KEY environment variable not set")
+            return@runTest
+        }
+
+        // Given: Repository with valid API key but invalid movie ID
+        val repository = MoviesRepository.factory(apiKey = testApiKey)
+
+        // When: Consumer requests external IDs for non-existent movie
+        val result = repository.getMovieExternalIds(movieId = INVALID_MOVIE_ID)
+
+        // Then: Consumer receives proper error handling
+        assertTrue(
+            result is DataResult.Failure,
+            "Expected failure result for non-existent movie external IDs",
+        )
+
+        val errorMessage = result.message
+        assertNotNull(errorMessage, "Error message should be provided")
+        assertTrue(
+            errorMessage.contains("404") ||
+                errorMessage.contains("not found", ignoreCase = true) ||
+                errorMessage.contains("could not be found", ignoreCase = true),
+            "Error should indicate movie not found, got: $errorMessage",
+        )
+
+        println("✅ External IDs error handling integration test passed")
+        println("\tError message: $errorMessage")
+    }
+
+    @Test
+    fun `movie external ids authentication error handling`() = runTest(timeout = TEST_TIMEOUT) {
+        // Given: Repository with invalid API key (simulating real auth failure)
+        val repository = MoviesRepository.factory(apiKey = "invalid_api_key_12345")
+
+        // When: Consumer attempts to get external IDs with invalid credentials
+        val result = repository.getMovieExternalIds(movieId = FIGHT_CLUB_MOVIE_ID)
+
+        // Then: Consumer receives authentication failure
+        assertTrue(result is DataResult.Failure, "Expected failure result for invalid API key")
+
+        val errorMessage = result.message
+        assertNotNull(errorMessage, "Error message should be provided to consumer")
+        assertTrue(
+            errorMessage.contains("401") ||
+                errorMessage.contains("Unauthorized") ||
+                errorMessage.contains("invalid", ignoreCase = true),
+            "Error message should indicate authentication issue, got: $errorMessage",
+        )
+
+        println("✅ External IDs authentication error integration test passed")
+        println("\tError message: $errorMessage")
+    }
+
+    @Test
+    fun `movie external ids edge cases with extreme movie IDs`() = runTest(timeout = TEST_TIMEOUT) {
+        val testApiKey = apiKey ?: run {
+            println("Skipping integration test - TMDB_API_KEY environment variable not set")
+            return@runTest
+        }
+
+        // Given: Repository for testing edge case parameter handling
+        val repository = MoviesRepository.factory(apiKey = testApiKey)
+
+        // When: Consumer provides edge case movie IDs
+
+        // Test with zero movie ID
+        val zeroIdResult = repository.getMovieExternalIds(movieId = 0)
+
+        // Test with negative movie ID
+        val negativeIdResult = repository.getMovieExternalIds(movieId = -1)
+
+        // Test with very large movie ID
+        val largeIdResult = repository.getMovieExternalIds(movieId = 999999999)
+
+        // Then: Repository should handle edge cases gracefully
+
+        // Zero and negative IDs should typically fail
+        assertTrue(
+            zeroIdResult is DataResult.Failure,
+            "Zero movie ID should fail for external IDs",
+        )
+        assertTrue(
+            negativeIdResult is DataResult.Failure,
+            "Negative movie ID should fail for external IDs",
+        )
+        assertTrue(
+            largeIdResult is DataResult.Failure,
+            "Very large movie ID should fail for external IDs",
+        )
+
+        // Verify error messages are provided
+        assertNotNull(zeroIdResult.message, "Zero ID failure should include error message")
+        assertNotNull(negativeIdResult.message, "Negative ID failure should include error message")
+        assertNotNull(largeIdResult.message, "Large ID failure should include error message")
+
+        println("✅ External IDs edge cases test passed")
+        println("\tZero ID: Failed as expected")
+        println("\tNegative ID: Failed as expected")
+        println("\tLarge ID: Failed as expected")
+    }
+
+    @Test
+    fun `movie external ids cross platform compatibility`() = runTest(timeout = TEST_TIMEOUT) {
+        val testApiKey = apiKey ?: run {
+            println("Skipping integration test - TMDB_API_KEY environment variable not set")
+            return@runTest
+        }
+
+        // Given: Repository that should work across KMP targets
+        val repository = MoviesRepository.factory(apiKey = testApiKey)
+
+        // When: Consumer requests external IDs (this test runs on different platforms via KMP)
+        val result = repository.getMovieExternalIds(movieId = FIGHT_CLUB_MOVIE_ID)
+
+        // Then: Should work consistently across Android, iOS, JVM targets
+        assertTrue(result is DataResult.Success, "External IDs should work on all KMP targets")
+
+        val externalIds = result.data
+
+        // Verify core functionality works across platforms
+        assertEquals(FIGHT_CLUB_MOVIE_ID, externalIds.id, "Movie ID should be consistent across platforms")
+
+        // Verify Kotlin data classes work properly across platforms
+        assertTrue(
+            externalIds.toString().contains("TmdbMovieExternalIds"),
+            "Domain model should serialize consistently across platforms",
+        )
+
+        // Verify nullable handling works across platforms (Kotlin type system ensures correctness)
+
+        println("✅ External IDs cross-platform compatibility test passed")
+        println("\tTested on current platform - KMP external IDs functionality works correctly")
+    }
+
+    private companion object {
+        const val FIGHT_CLUB_MOVIE_ID = 550 // Fight Club (1999) - stable for external IDs testing
+        const val THE_MATRIX_MOVIE_ID = 603 // The Matrix (1999) - stable for comparison testing
+        const val THE_GODFATHER_MOVIE_ID = 238 // The Godfather (1972) - classic for minimal presence testing
+        const val INVALID_MOVIE_ID = 999999999 // Non-existent movie ID for error testing
+        val TEST_TIMEOUT = 30.seconds
+    }
+}

--- a/data/movies/src/commonMain/kotlin/dev/euryperez/tmdb/data/movies/MoviesRepository.kt
+++ b/data/movies/src/commonMain/kotlin/dev/euryperez/tmdb/data/movies/MoviesRepository.kt
@@ -4,6 +4,7 @@ import dev.euryperez.tmdb.core.models.movies.TmdbMovie
 import dev.euryperez.tmdb.core.models.movies.TmdbMovieAlternativeTitles
 import dev.euryperez.tmdb.core.models.movies.TmdbMovieCredits
 import dev.euryperez.tmdb.core.models.movies.TmdbMovieDetails
+import dev.euryperez.tmdb.core.models.movies.TmdbMovieExternalIds
 import dev.euryperez.tmdb.data.common.models.DataResult
 import dev.euryperez.tmdb.data.movies.api.MoviesApi
 
@@ -29,6 +30,8 @@ interface MoviesRepository {
     suspend fun getMovieCredits(movieId: Int, language: String = "en-US"): DataResult<TmdbMovieCredits>
 
     suspend fun getMovieAlternativeTitles(movieId: Int): DataResult<TmdbMovieAlternativeTitles>
+
+    suspend fun getMovieExternalIds(movieId: Int): DataResult<TmdbMovieExternalIds>
 
     companion object {
         private var instance: MoviesRepository? = null

--- a/data/movies/src/commonMain/kotlin/dev/euryperez/tmdb/data/movies/MoviesRepositoryImpl.kt
+++ b/data/movies/src/commonMain/kotlin/dev/euryperez/tmdb/data/movies/MoviesRepositoryImpl.kt
@@ -4,6 +4,7 @@ import dev.euryperez.tmdb.core.models.movies.TmdbMovie
 import dev.euryperez.tmdb.core.models.movies.TmdbMovieAlternativeTitles
 import dev.euryperez.tmdb.core.models.movies.TmdbMovieCredits
 import dev.euryperez.tmdb.core.models.movies.TmdbMovieDetails
+import dev.euryperez.tmdb.core.models.movies.TmdbMovieExternalIds
 import dev.euryperez.tmdb.core.utils.coroutines.DispatcherProvider
 import dev.euryperez.tmdb.core.utils.coroutines.DispatcherProviderImpl
 import dev.euryperez.tmdb.data.common.extensions.toDataResult
@@ -83,6 +84,14 @@ internal class MoviesRepositoryImpl(
     override suspend fun getMovieAlternativeTitles(movieId: Int): DataResult<TmdbMovieAlternativeTitles> {
         return withContext(dispatcherProvider.default) {
             moviesApi.getMovieAlternativeTitles(movieId = movieId)
+                .toDataResult()
+                .map { it.toDomain() }
+        }
+    }
+
+    override suspend fun getMovieExternalIds(movieId: Int): DataResult<TmdbMovieExternalIds> {
+        return withContext(dispatcherProvider.default) {
+            moviesApi.getMovieExternalIds(movieId = movieId)
                 .toDataResult()
                 .map { it.toDomain() }
         }

--- a/data/movies/src/commonMain/kotlin/dev/euryperez/tmdb/data/movies/api/MoviesApi.kt
+++ b/data/movies/src/commonMain/kotlin/dev/euryperez/tmdb/data/movies/api/MoviesApi.kt
@@ -5,6 +5,7 @@ import dev.euryperez.tmdb.core.network.models.ApiResult
 import dev.euryperez.tmdb.data.movies.api.dtos.MovieAlternativeTitlesResponseDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.MovieCreditsResponseDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.MovieDetailsDTO
+import dev.euryperez.tmdb.data.movies.api.dtos.MovieExternalIdsResponseDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.MovieListResponseDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.NowPlayingMoviesResponseDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.UpcomingMoviesResponseDTO
@@ -31,6 +32,8 @@ internal interface MoviesApi {
     suspend fun getMovieCredits(movieId: Int, language: String = "en-US"): ApiResult<MovieCreditsResponseDTO>
 
     suspend fun getMovieAlternativeTitles(movieId: Int): ApiResult<MovieAlternativeTitlesResponseDTO>
+
+    suspend fun getMovieExternalIds(movieId: Int): ApiResult<MovieExternalIdsResponseDTO>
 
     companion object {
         private var instance: MoviesApi? = null

--- a/data/movies/src/commonMain/kotlin/dev/euryperez/tmdb/data/movies/api/MoviesApiImpl.kt
+++ b/data/movies/src/commonMain/kotlin/dev/euryperez/tmdb/data/movies/api/MoviesApiImpl.kt
@@ -5,6 +5,7 @@ import dev.euryperez.tmdb.core.network.models.ApiResult
 import dev.euryperez.tmdb.data.movies.api.dtos.MovieAlternativeTitlesResponseDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.MovieCreditsResponseDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.MovieDetailsDTO
+import dev.euryperez.tmdb.data.movies.api.dtos.MovieExternalIdsResponseDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.MovieListResponseDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.NowPlayingMoviesResponseDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.UpcomingMoviesResponseDTO
@@ -72,6 +73,14 @@ internal class MoviesApiImpl(val httpClient: HttpClient) : MoviesApi {
     override suspend fun getMovieAlternativeTitles(movieId: Int): ApiResult<MovieAlternativeTitlesResponseDTO> {
         return httpClient.getAsApiResult(
             MovieResource.Id.AlternativeTitles(
+                parent = MovieResource.Id(movieId = movieId),
+            ),
+        )
+    }
+
+    override suspend fun getMovieExternalIds(movieId: Int): ApiResult<MovieExternalIdsResponseDTO> {
+        return httpClient.getAsApiResult(
+            MovieResource.Id.ExternalIds(
                 parent = MovieResource.Id(movieId = movieId),
             ),
         )

--- a/data/movies/src/commonMain/kotlin/dev/euryperez/tmdb/data/movies/api/dtos/MovieExternalIdsResponseDTO.kt
+++ b/data/movies/src/commonMain/kotlin/dev/euryperez/tmdb/data/movies/api/dtos/MovieExternalIdsResponseDTO.kt
@@ -1,0 +1,19 @@
+package dev.euryperez.tmdb.data.movies.api.dtos
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class MovieExternalIdsResponseDTO(
+    val id: Int,
+    @SerialName("imdb_id")
+    val imdbId: String?,
+    @SerialName("wikidata_id")
+    val wikidataId: String?,
+    @SerialName("facebook_id")
+    val facebookId: String?,
+    @SerialName("instagram_id")
+    val instagramId: String?,
+    @SerialName("twitter_id")
+    val twitterId: String?,
+)

--- a/data/movies/src/commonMain/kotlin/dev/euryperez/tmdb/data/movies/api/resources/MovieResource.kt
+++ b/data/movies/src/commonMain/kotlin/dev/euryperez/tmdb/data/movies/api/resources/MovieResource.kt
@@ -15,6 +15,9 @@ internal class MovieResource {
 
         @Resource("alternative_titles")
         class AlternativeTitles(val parent: Id)
+
+        @Resource("external_ids")
+        class ExternalIds(val parent: Id)
     }
 
     @Resource("popular")

--- a/data/movies/src/commonMain/kotlin/dev/euryperez/tmdb/data/movies/mappers/MovieDTOMappers.kt
+++ b/data/movies/src/commonMain/kotlin/dev/euryperez/tmdb/data/movies/mappers/MovieDTOMappers.kt
@@ -8,6 +8,7 @@ import dev.euryperez.tmdb.core.models.movies.TmdbMovie
 import dev.euryperez.tmdb.core.models.movies.TmdbMovieAlternativeTitles
 import dev.euryperez.tmdb.core.models.movies.TmdbMovieCredits
 import dev.euryperez.tmdb.core.models.movies.TmdbMovieDetails
+import dev.euryperez.tmdb.core.models.movies.TmdbMovieExternalIds
 import dev.euryperez.tmdb.core.models.movies.TmdbProductionCompany
 import dev.euryperez.tmdb.core.models.movies.TmdbProductionCountry
 import dev.euryperez.tmdb.core.utils.extensions.localDateOrNull
@@ -19,6 +20,7 @@ import dev.euryperez.tmdb.data.movies.api.dtos.MovieCreditsResponseDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.MovieCrewMemberDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.MovieDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.MovieDetailsDTO
+import dev.euryperez.tmdb.data.movies.api.dtos.MovieExternalIdsResponseDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.ProductionCompanyDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.ProductionCountryDTO
 
@@ -129,4 +131,13 @@ internal fun AlternativeTitleDTO.toDomain() = TmdbAlternativeTitle(
     countryCode = iso31661,
     title = title,
     type = type,
+)
+
+internal fun MovieExternalIdsResponseDTO.toDomain() = TmdbMovieExternalIds(
+    id = id,
+    imdbId = imdbId,
+    wikidataId = wikidataId,
+    facebookId = facebookId,
+    instagramId = instagramId,
+    twitterId = twitterId,
 )

--- a/data/movies/src/commonTest/kotlin/dev/euryperez/tmdb/data/movies/DtoTestExtensions.kt
+++ b/data/movies/src/commonTest/kotlin/dev/euryperez/tmdb/data/movies/DtoTestExtensions.kt
@@ -9,6 +9,7 @@ import dev.euryperez.tmdb.data.movies.api.dtos.MovieCreditsResponseDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.MovieCrewMemberDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.MovieDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.MovieDetailsDTO
+import dev.euryperez.tmdb.data.movies.api.dtos.MovieExternalIdsResponseDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.MovieListResponseDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.NowPlayingMoviesResponseDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.UpcomingMoviesResponseDTO
@@ -193,4 +194,20 @@ internal fun MovieAlternativeTitlesResponseDTO.Companion.test(
 ): MovieAlternativeTitlesResponseDTO = MovieAlternativeTitlesResponseDTO(
     id = id,
     titles = titles,
+)
+
+internal fun MovieExternalIdsResponseDTO.Companion.test(
+    id: Int = 550,
+    imdbId: String? = "tt0137523",
+    wikidataId: String? = "Q190050",
+    facebookId: String? = "FightClubFilm",
+    instagramId: String? = "fightclubmovie",
+    twitterId: String? = "fightclub",
+): MovieExternalIdsResponseDTO = MovieExternalIdsResponseDTO(
+    id = id,
+    imdbId = imdbId,
+    wikidataId = wikidataId,
+    facebookId = facebookId,
+    instagramId = instagramId,
+    twitterId = twitterId,
 )

--- a/data/movies/src/commonTest/kotlin/dev/euryperez/tmdb/data/movies/MovieExternalIdsRepositoryTest.kt
+++ b/data/movies/src/commonTest/kotlin/dev/euryperez/tmdb/data/movies/MovieExternalIdsRepositoryTest.kt
@@ -1,0 +1,276 @@
+package dev.euryperez.tmdb.data.movies
+
+import dev.euryperez.tmdb.core.network.models.ApiResult
+import dev.euryperez.tmdb.core.test.BaseTest
+import dev.euryperez.tmdb.core.test.rules.MainCoroutineRule
+import dev.euryperez.tmdb.data.common.models.DataResult
+import dev.euryperez.tmdb.data.movies.api.MoviesApi
+import dev.euryperez.tmdb.data.movies.api.dtos.MovieExternalIdsResponseDTO
+import dev.euryperez.tmdb.data.movies.mappers.toDomain
+import dev.euryperez.tmdb.data.movies.utils.test
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MovieExternalIdsRepositoryTest : BaseTest {
+
+    val mainCoroutineRule = MainCoroutineRule()
+
+    private val moviesApi = mock<MoviesApi>()
+
+    @BeforeTest
+    override fun setup() {
+        mainCoroutineRule.setup()
+    }
+
+    @AfterTest
+    override fun tearDown() {
+        mainCoroutineRule.tearDown()
+    }
+
+    @Test
+    fun `getMovieExternalIds returns success with mapped external ids when api call succeeds`() = runTest {
+        // Given
+        val movieId = 550
+        val dto = MovieExternalIdsResponseDTO.test()
+        val expected = dto.toDomain()
+
+        everySuspend { moviesApi.getMovieExternalIds(movieId) }
+            .returns(ApiResult.Success(dto))
+
+        // When
+        val result = MoviesRepository.test(moviesApi).getMovieExternalIds(movieId)
+
+        // Then
+        assertTrue(result is DataResult.Success)
+        assertEquals(expected, result.data)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            moviesApi.getMovieExternalIds(movieId)
+        }
+    }
+
+    @Test
+    fun `getMovieExternalIds returns success with null external ids when api returns null values`() = runTest {
+        // Given
+        val movieId = 999
+        val dto = MovieExternalIdsResponseDTO.test(
+            id = movieId,
+            imdbId = null,
+            wikidataId = null,
+            facebookId = null,
+            instagramId = null,
+            twitterId = null,
+        )
+
+        everySuspend { moviesApi.getMovieExternalIds(movieId) }
+            .returns(ApiResult.Success(dto))
+
+        // When
+        val result = MoviesRepository.test(moviesApi).getMovieExternalIds(movieId)
+
+        // Then
+        assertTrue(result is DataResult.Success)
+        assertEquals(999, result.data.id)
+        assertNull(result.data.imdbId)
+        assertNull(result.data.wikidataId)
+        assertNull(result.data.facebookId)
+        assertNull(result.data.instagramId)
+        assertNull(result.data.twitterId)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            moviesApi.getMovieExternalIds(movieId)
+        }
+    }
+
+    @Test
+    fun `getMovieExternalIds returns failure when api call fails with http error`() = runTest {
+        // Given
+        val movieId = 550
+        val errorMessage = "Movie not found"
+
+        everySuspend { moviesApi.getMovieExternalIds(movieId) }
+            .returns(ApiResult.Error.HttpError(404, errorMessage))
+
+        // When
+        val result = MoviesRepository.test(moviesApi).getMovieExternalIds(movieId)
+
+        // Then
+        assertTrue(result is DataResult.Failure)
+        assertEquals(errorMessage, result.message)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            moviesApi.getMovieExternalIds(movieId)
+        }
+    }
+
+    @Test
+    fun `getMovieExternalIds returns failure when api call fails with network error`() = runTest {
+        // Given
+        val movieId = 550
+        val errorMessage = "Network connection failed"
+
+        everySuspend { moviesApi.getMovieExternalIds(movieId) }
+            .returns(ApiResult.Error.NetworkError(errorMessage))
+
+        // When
+        val result = MoviesRepository.test(moviesApi).getMovieExternalIds(movieId)
+
+        // Then
+        assertTrue(result is DataResult.Failure)
+        assertEquals(errorMessage, result.message)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            moviesApi.getMovieExternalIds(movieId)
+        }
+    }
+
+    @Test
+    fun `getMovieExternalIds returns failure when api call fails with serialization error`() = runTest {
+        // Given
+        val movieId = 550
+        val errorMessage = "JSON parsing error"
+
+        everySuspend { moviesApi.getMovieExternalIds(movieId) }
+            .returns(ApiResult.Error.SerializationError(errorMessage))
+
+        // When
+        val result = MoviesRepository.test(moviesApi).getMovieExternalIds(movieId)
+
+        // Then
+        assertTrue(result is DataResult.Failure)
+        assertEquals(errorMessage, result.message)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            moviesApi.getMovieExternalIds(movieId)
+        }
+    }
+
+    @Test
+    fun `getMovieExternalIds handles all external id types correctly`() = runTest {
+        // Given
+        val movieId = 550
+        val dto = MovieExternalIdsResponseDTO.test(
+            id = movieId,
+            imdbId = "tt0137523",
+            wikidataId = "Q190050",
+            facebookId = "FightClubFilm",
+            instagramId = "fightclubmovie",
+            twitterId = "fightclub",
+        )
+
+        everySuspend { moviesApi.getMovieExternalIds(movieId) }
+            .returns(ApiResult.Success(dto))
+
+        // When
+        val result = MoviesRepository.test(moviesApi).getMovieExternalIds(movieId)
+
+        // Then
+        assertTrue(result is DataResult.Success)
+        assertEquals(550, result.data.id)
+        assertEquals("tt0137523", result.data.imdbId)
+        assertEquals("Q190050", result.data.wikidataId)
+        assertEquals("FightClubFilm", result.data.facebookId)
+        assertEquals("fightclubmovie", result.data.instagramId)
+        assertEquals("fightclub", result.data.twitterId)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            moviesApi.getMovieExternalIds(movieId)
+        }
+    }
+
+    @Test
+    fun `getMovieExternalIds passes correct movieId parameter to api`() = runTest {
+        // Given
+        val movieId = 12345
+        val dto = MovieExternalIdsResponseDTO.test()
+
+        everySuspend { moviesApi.getMovieExternalIds(movieId) }
+            .returns(ApiResult.Success(dto))
+
+        // When
+        MoviesRepository.test(moviesApi).getMovieExternalIds(movieId)
+
+        // Then
+        verifySuspend(VerifyMode.exactly(1)) {
+            moviesApi.getMovieExternalIds(12345)
+        }
+    }
+
+    @Test
+    fun `getMovieExternalIds maps DTO to domain model correctly`() = runTest {
+        // Given
+        val movieId = 550
+        val dto = MovieExternalIdsResponseDTO.test(
+            id = 550,
+            imdbId = "tt1234567",
+            wikidataId = "Q123456",
+            facebookId = "testmovie",
+            instagramId = "testmovieig",
+            twitterId = "testmovietwitter",
+        )
+
+        everySuspend { moviesApi.getMovieExternalIds(movieId) }
+            .returns(ApiResult.Success(dto))
+
+        // When
+        val result = MoviesRepository.test(moviesApi).getMovieExternalIds(movieId)
+
+        // Then
+        assertTrue(result is DataResult.Success)
+        assertEquals(550, result.data.id)
+        assertEquals("tt1234567", result.data.imdbId)
+        assertEquals("Q123456", result.data.wikidataId)
+        assertEquals("testmovie", result.data.facebookId)
+        assertEquals("testmovieig", result.data.instagramId)
+        assertEquals("testmovietwitter", result.data.twitterId)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            moviesApi.getMovieExternalIds(movieId)
+        }
+    }
+
+    @Test
+    fun `getMovieExternalIds handles partial external id data correctly`() = runTest {
+        // Given
+        val movieId = 123
+        val dto = MovieExternalIdsResponseDTO.test(
+            id = movieId,
+            imdbId = "tt9876543",
+            wikidataId = null,
+            facebookId = "partialmovie",
+            instagramId = null,
+            twitterId = "partialmovietwitter",
+        )
+
+        everySuspend { moviesApi.getMovieExternalIds(movieId) }
+            .returns(ApiResult.Success(dto))
+
+        // When
+        val result = MoviesRepository.test(moviesApi).getMovieExternalIds(movieId)
+
+        // Then
+        assertTrue(result is DataResult.Success)
+        assertEquals(123, result.data.id)
+        assertEquals("tt9876543", result.data.imdbId)
+        assertNull(result.data.wikidataId)
+        assertEquals("partialmovie", result.data.facebookId)
+        assertNull(result.data.instagramId)
+        assertEquals("partialmovietwitter", result.data.twitterId)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            moviesApi.getMovieExternalIds(movieId)
+        }
+    }
+}

--- a/data/movies/src/commonTest/kotlin/dev/euryperez/tmdb/data/movies/mappers/MovieDTOMappersTest.kt
+++ b/data/movies/src/commonTest/kotlin/dev/euryperez/tmdb/data/movies/mappers/MovieDTOMappersTest.kt
@@ -2,15 +2,18 @@ package dev.euryperez.tmdb.data.movies.mappers
 
 import dev.euryperez.tmdb.core.models.movies.TmdbAlternativeTitle
 import dev.euryperez.tmdb.core.models.movies.TmdbMovieAlternativeTitles
+import dev.euryperez.tmdb.core.models.movies.TmdbMovieExternalIds
 import dev.euryperez.tmdb.core.test.BaseTest
 import dev.euryperez.tmdb.core.test.rules.MainCoroutineRule
 import dev.euryperez.tmdb.data.movies.api.dtos.AlternativeTitleDTO
 import dev.euryperez.tmdb.data.movies.api.dtos.MovieAlternativeTitlesResponseDTO
+import dev.euryperez.tmdb.data.movies.api.dtos.MovieExternalIdsResponseDTO
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MovieDTOMappersTest : BaseTest {
@@ -288,5 +291,157 @@ class MovieDTOMappersTest : BaseTest {
         assertEquals("Original Title", result.titles[0].type)
         assertEquals(null, result.titles[1].type)
         assertEquals("Alternative Title", result.titles[2].type)
+    }
+
+    // ========================================
+    // MovieExternalIdsResponseDTO Tests
+    // ========================================
+
+    @Test
+    fun `MovieExternalIdsResponseDTO toDomain maps all fields correctly`() {
+        // Given
+        val dto = MovieExternalIdsResponseDTO(
+            id = 550,
+            imdbId = "tt0137523",
+            wikidataId = "Q190050",
+            facebookId = "FightClubFilm",
+            instagramId = "fightclubmovie",
+            twitterId = "fightclub",
+        )
+
+        // When
+        val result = dto.toDomain()
+
+        // Then
+        val expected = TmdbMovieExternalIds(
+            id = 550,
+            imdbId = "tt0137523",
+            wikidataId = "Q190050",
+            facebookId = "FightClubFilm",
+            instagramId = "fightclubmovie",
+            twitterId = "fightclub",
+        )
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `MovieExternalIdsResponseDTO toDomain handles all null external ids`() {
+        // Given
+        val dto = MovieExternalIdsResponseDTO(
+            id = 999,
+            imdbId = null,
+            wikidataId = null,
+            facebookId = null,
+            instagramId = null,
+            twitterId = null,
+        )
+
+        // When
+        val result = dto.toDomain()
+
+        // Then
+        assertEquals(999, result.id)
+        assertNull(result.imdbId)
+        assertNull(result.wikidataId)
+        assertNull(result.facebookId)
+        assertNull(result.instagramId)
+        assertNull(result.twitterId)
+    }
+
+    @Test
+    fun `MovieExternalIdsResponseDTO toDomain handles partial external ids`() {
+        // Given
+        val dto = MovieExternalIdsResponseDTO(
+            id = 123,
+            imdbId = "tt1234567",
+            wikidataId = null,
+            facebookId = "partialmovie",
+            instagramId = null,
+            twitterId = "partialmovietwitter",
+        )
+
+        // When
+        val result = dto.toDomain()
+
+        // Then
+        assertEquals(123, result.id)
+        assertEquals("tt1234567", result.imdbId)
+        assertNull(result.wikidataId)
+        assertEquals("partialmovie", result.facebookId)
+        assertNull(result.instagramId)
+        assertEquals("partialmovietwitter", result.twitterId)
+    }
+
+    @Test
+    fun `MovieExternalIdsResponseDTO toDomain preserves id field correctly`() {
+        // Given
+        val movieId = 12345
+        val dto = MovieExternalIdsResponseDTO(
+            id = movieId,
+            imdbId = "tt9999999",
+            wikidataId = "Q999999",
+            facebookId = "testmovie",
+            instagramId = "testmovieig",
+            twitterId = "testmovietwitter",
+        )
+
+        // When
+        val result = dto.toDomain()
+
+        // Then
+        assertEquals(movieId, result.id)
+        assertEquals("tt9999999", result.imdbId)
+        assertEquals("Q999999", result.wikidataId)
+        assertEquals("testmovie", result.facebookId)
+        assertEquals("testmovieig", result.instagramId)
+        assertEquals("testmovietwitter", result.twitterId)
+    }
+
+    @Test
+    fun `MovieExternalIdsResponseDTO toDomain handles only IMDb id`() {
+        // Given
+        val dto = MovieExternalIdsResponseDTO(
+            id = 550,
+            imdbId = "tt0137523",
+            wikidataId = null,
+            facebookId = null,
+            instagramId = null,
+            twitterId = null,
+        )
+
+        // When
+        val result = dto.toDomain()
+
+        // Then
+        assertEquals(550, result.id)
+        assertEquals("tt0137523", result.imdbId)
+        assertNull(result.wikidataId)
+        assertNull(result.facebookId)
+        assertNull(result.instagramId)
+        assertNull(result.twitterId)
+    }
+
+    @Test
+    fun `MovieExternalIdsResponseDTO toDomain handles social media ids only`() {
+        // Given
+        val dto = MovieExternalIdsResponseDTO(
+            id = 789,
+            imdbId = null,
+            wikidataId = null,
+            facebookId = "socialmovie",
+            instagramId = "socialmovieig",
+            twitterId = "socialmovietwitter",
+        )
+
+        // When
+        val result = dto.toDomain()
+
+        // Then
+        assertEquals(789, result.id)
+        assertNull(result.imdbId)
+        assertNull(result.wikidataId)
+        assertEquals("socialmovie", result.facebookId)
+        assertEquals("socialmovieig", result.instagramId)
+        assertEquals("socialmovietwitter", result.twitterId)
     }
 }


### PR DESCRIPTION
## Related Issues
Resolves #4

## Summary
Implements the Movie External IDs endpoint functionality to retrieve external ID information (IMDb, Wikidata, Facebook, Instagram, Twitter) for movies from the TMDB API.

## Changes
- **Core Models**: Added `TmdbMovieExternalIds` data class in `core/models` for domain representation
- **Data Transfer Objects**: Created `MovieExternalIdsResponseDTO` for API response mapping
- **API Layer**: Implemented `getMovieExternalIds` method in `MoviesApi` and `MoviesApiImpl`
- **Repository Layer**: Added support in `MoviesRepository` and `MoviesRepositoryImpl` for external IDs retrieval
- **Data Mappers**: Created extension functions to convert DTOs to domain models with proper null handling
- **Unit Tests**: Comprehensive test coverage for DTO mappers with various scenarios
- **Integration Tests**: End-to-end testing for the external IDs endpoint
- **Resource Configuration**: Updated `MovieResource` to include external IDs endpoint path

## Testing
All new functionality includes comprehensive unit and integration tests. The implementation follows existing codebase patterns for consistency and maintainability.